### PR TITLE
fix: make the trait, state, and property names predictable for use in…

### DIFF
--- a/lib/src/repository/devices_repository.dart
+++ b/lib/src/repository/devices_repository.dart
@@ -36,8 +36,7 @@ class DevicesRepository {
   static Future<Device> getDeviceDetails(Request request, String id) async {
     final req = GgetDevice((b) => b..vars.deviceId = id);
     final res = await Repository()
-        .fetch(request, req.operation,
-        variables: req.vars.toJson());
+        .fetch(request, req.operation, variables: req.vars.toJson());
 
     final device = GgetDeviceData.fromJson(res.data!)!.device;
     return Device(
@@ -99,7 +98,7 @@ class DevicesRepository {
     }
 
     return deviceTraits.map<Trait>((trait) {
-      switch (trait.name) {
+      switch (trait.name as GTraitName) {
         case GTraitName.THERMOSTAT_SETTING:
           return ThermostatRepository.getThermostatTrait(trait);
         case GTraitName.LOCK:
@@ -148,6 +147,7 @@ abstract class Trait {
   late final String name;
   late final Set<State> states;
   late final Set<Property> properties;
+
   Trait(this.name, this.states, this.properties);
 
   State<dynamic>? stateWhereType<T extends State<dynamic>>() {
@@ -183,7 +183,7 @@ abstract class Property<T> {
 }
 
 class UnknownTrait extends Trait {
-  UnknownTrait(String name) : super(name, {UnknownState()}, {});
+  UnknownTrait([String name = 'Unknown']) : super(name, {UnknownState()}, {});
 }
 
 class DeviceNameId {

--- a/lib/src/repository/traits/battery_level_repository.dart
+++ b/lib/src/repository/traits/battery_level_repository.dart
@@ -1,3 +1,5 @@
+import 'package:yonomi_platform_sdk/third_party/yonomi_graphql_schema/schema.docs.schema.gql.dart';
+
 import '../devices_repository.dart';
 
 class BatteryLevelRepository {
@@ -17,5 +19,8 @@ class BatteryLevel extends State<int> {
 }
 
 class BatteryLevelTrait extends Trait {
-  BatteryLevelTrait(State state) : super('battery_level', {state}, {});
+  int? get batteryLevel => stateWhereType<BatteryLevel>()?.value;
+
+  BatteryLevelTrait(BatteryLevel batteryLevel)
+      : super(GTraitName.BATTERY_LEVEL.name.toLowerCase(), {batteryLevel}, {});
 }

--- a/lib/src/repository/traits/brightness_repository.dart
+++ b/lib/src/repository/traits/brightness_repository.dart
@@ -2,6 +2,7 @@ import 'package:yonomi_platform_sdk/src/queries/brightness/make_brightness_actio
 import 'package:yonomi_platform_sdk/src/repository/devices_repository.dart';
 import 'package:yonomi_platform_sdk/src/repository/repository.dart';
 import 'package:yonomi_platform_sdk/src/request/request.dart';
+import 'package:yonomi_platform_sdk/third_party/yonomi_graphql_schema/schema.docs.schema.gql.dart';
 
 class BrightnessRepository {
   static BrightnessTrait getBrightnessTrait(dynamic trait) {
@@ -29,6 +30,8 @@ class Brightness extends State<int?> {
 }
 
 class BrightnessTrait extends Trait {
+  int? get brightness => stateWhereType<Brightness>()?.value;
+
   BrightnessTrait(Brightness brightness)
-      : super('brightness', {brightness}, {});
+      : super(GTraitName.BRIGHTNESS.name.toLowerCase(), {brightness}, {});
 }

--- a/lib/src/repository/traits/color_repository.dart
+++ b/lib/src/repository/traits/color_repository.dart
@@ -53,7 +53,9 @@ class HSBColor extends State<GHSBColorValueInput> {
 }
 
 class ColorTrait extends Trait {
-  final HSBColor color;
-  ColorTrait(this.color)
-      : super('color', [color].toSet(), Set.identity());
+  HSBColor get color => stateWhereType<HSBColor>() as HSBColor;
+
+  ColorTrait(HSBColor color)
+      : super(GTraitName.COLOR.name.toLowerCase(), [color].toSet(),
+            Set.identity());
 }

--- a/lib/src/repository/traits/color_temperature_repository.dart
+++ b/lib/src/repository/traits/color_temperature_repository.dart
@@ -2,6 +2,7 @@ import 'package:yonomi_platform_sdk/src/queries/color_temperature/make_colortemp
 import 'package:yonomi_platform_sdk/src/repository/devices_repository.dart';
 import 'package:yonomi_platform_sdk/src/repository/repository.dart';
 import 'package:yonomi_platform_sdk/src/request/request.dart';
+import 'package:yonomi_platform_sdk/third_party/yonomi_graphql_schema/schema.docs.schema.gql.dart';
 
 class ColorTemperatureRepository {
   static ColorTemperatureTrait getColorTemperatureTrait(dynamic trait) {
@@ -33,7 +34,7 @@ class ColorTemperatureRepository {
 
 class ColorTemperature extends State<int?> {
   ColorTemperature(int? colorTemperature)
-      : super('color_temperature', colorTemperature);
+      : super('colorTemperature', colorTemperature);
 }
 
 class IntRange {
@@ -52,7 +53,7 @@ class SupportedColorTemperatureRange extends Property<IntRange> {
 
 class ColorTemperatureTrait extends Trait {
   ColorTemperatureTrait(Set<State> states, Set<Property> properties)
-      : super('color_temperature', states, properties);
+      : super(GTraitName.COLOR_TEMPERATURE.name.toLowerCase(), states, properties);
 
   int? get colorTemperature => stateWhereType<ColorTemperature>()?.value;
 

--- a/lib/src/repository/traits/lock_repository.dart
+++ b/lib/src/repository/traits/lock_repository.dart
@@ -1,5 +1,6 @@
 import 'package:yonomi_platform_sdk/src/queries/lock/make_lock_unlock_action_request/query.req.gql.dart';
 import 'package:yonomi_platform_sdk/src/repository/repository.dart';
+import 'package:yonomi_platform_sdk/third_party/yonomi_graphql_schema/schema.docs.schema.gql.dart';
 import 'package:yonomi_platform_sdk/yonomi-sdk.dart';
 
 class LockRepository {
@@ -30,11 +31,11 @@ class LockRepository {
 }
 
 class IsLocked extends State<bool?> {
-  IsLocked(bool? value) : super('IsLocked', value);
+  IsLocked(bool? value) : super('isLocked', value);
 }
 
 class IsJammed extends State<bool?> {
-  IsJammed(bool? value) : super('IsJammed', value);
+  IsJammed(bool? value) : super('isJammed', value);
 }
 
 class SupportsIsJammed extends Property<bool?> {
@@ -43,6 +44,9 @@ class SupportsIsJammed extends Property<bool?> {
 
 class LockTrait extends Trait {
   bool? get supportsIsJammed => propertyWhereType<SupportsIsJammed>().value;
+  bool? get isLocked => stateWhereType<IsLocked>()?.value;
+  bool? get isJammed => stateWhereType<IsJammed>()?.value;
+
   LockTrait(Set<State> states, Set<Property> properties)
-      : super('lock', states, properties);
+      : super(GTraitName.LOCK.name.toLowerCase(), states, properties);
 }

--- a/lib/src/repository/traits/power_repository.dart
+++ b/lib/src/repository/traits/power_repository.dart
@@ -1,5 +1,6 @@
 import 'package:yonomi_platform_sdk/src/queries/power/make_power_action_request/query.req.gql.dart';
 import 'package:yonomi_platform_sdk/src/repository/repository.dart';
+import 'package:yonomi_platform_sdk/third_party/yonomi_graphql_schema/schema.docs.schema.gql.dart';
 import 'package:yonomi_platform_sdk/yonomi-sdk.dart';
 
 class PowerRepository {
@@ -36,7 +37,12 @@ class IsOnOff extends State<bool?> {
 }
 
 class PowerTrait extends Trait {
-  final SupportsDiscreteOnOff supportsDiscreteOnOff;
-  PowerTrait(State state, {required this.supportsDiscreteOnOff})
-      : super('power', {state}, {supportsDiscreteOnOff});
+  bool? get isOn => stateWhereType<IsOnOff>()?.value;
+  bool? get supportsDiscreteOnOff =>
+      propertyWhereType<SupportsDiscreteOnOff>().value;
+
+  PowerTrait(State state,
+      {required SupportsDiscreteOnOff supportsDiscreteOnOff})
+      : super(GTraitName.POWER.name.toLowerCase(), {state},
+            {supportsDiscreteOnOff});
 }

--- a/lib/src/repository/traits/thermostat_repository.dart
+++ b/lib/src/repository/traits/thermostat_repository.dart
@@ -114,16 +114,20 @@ class AvailableThermostatModes extends Property<Set<AvailableThermostatMode>> {
 
 class ThermostatTrait extends Trait {
   ThermostatTrait(Set<State> states, Set<Property> properties)
-      : super('thermostat_setting', states, properties);
+      : super(GTraitName.THERMOSTAT_SETTING.name.toLowerCase(), states,
+            properties);
+
+  double? get targetTemperature => stateWhereType<TargetTemperature>()?.value;
+  double? get ambientTemperature => stateWhereType<AmbientTemperature>()?.value;
+  AvailableFanMode? get fanMode => stateWhereType<FanMode>()?.value;
+  AvailableThermostatMode? get mode => stateWhereType<ThermostatMode>()?.value;
 
   Set<AvailableFanMode> get availableFanModes =>
       propertyWhereType<AvailableFanModes>().value;
   Set<AvailableThermostatMode> get availableThermostatModes =>
       propertyWhereType<AvailableThermostatModes>().value;
-
   TemperatureRange get heatSetPointRange =>
       propertyWhereType<HeatSetPointRange>().value;
-
   TemperatureRange get coolSetPointRange =>
       propertyWhereType<CoolSetPointRange>().value;
 }


### PR DESCRIPTION
… other applications determining types

This started when I noticed the trait names didn't follow a convention that would be useful as a consumer of the sdk. So, changing them to the `GTtaitName` values lowercased which seems to be how traits are named in our response payloads using the enum to name the traits made sense. I also added the same convenience methods to all of our traits since I was encountering some that did and some that didn't when working with the SDK in the device lab. 

From there I noticed the properties and states also had some disparities as far as following a common theme so I tried to make them match what we would expect to see on a query return as well. 

From there I was improving code coverage. 