### PR TITLE
build(.pubignore,.gitignore): change the gitignore and pubignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
     steps:
       - run:
           name: Publishing to pub.dev
-          command: dart pub publish
+          command: dart pub publish -f
 
   dependencies:
     description: "Download dependencies and setup global packages"

--- a/.gitignore
+++ b/.gitignore
@@ -27,10 +27,8 @@ pubspec.lock
 .pub-cache/
 .pub/
 build/
-lib/src/queries/*
-!lib/src/queries/**/*.graphql
-lib/third_party/yonomi_graphql_schema/*
-!lib/third_party/yonomi_graphql_schema/**/*.graphql
+lib/src/queries/**/*.dart
+lib/third_party/yonomi_graphql_schema/**/*.dart
 
 # Test Artifacts
 coverage/
@@ -77,5 +75,6 @@ coverage/
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 node_modules/
+process.yml
 package-lock.json
 package.json

--- a/.pubignore
+++ b/.pubignore
@@ -1,2 +1,2 @@
-!lib/src/queries/*
-!lib/third_party/yonomi_graphql_schema/*
+lib/src/queries/**/*.graphql
+lib/third_party/yonomi_graphql_schema/**/*.graphql


### PR DESCRIPTION
Note the `-f` added. Per the dart documentation: 

```
--force or -f
With this, pub does not ask for confirmation before publishing. Normally, it shows you the package contents and asks for you to confirm the upload.

If your package has errors, pub doesn’t upload it and exits with an error. In the event of warnings, your package is uploaded. To ensure that your package has no warnings before uploading, either don’t use --force, or use --dry-run first.
```